### PR TITLE
chore: release 3.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Change Log
 
+### v3.1.11(Aug 14, 2024)
+* Fixed crash issue in `DeallocateAllMessages`
+
 ### v3.1.10(Aug 2, 2024)
 * Fixed crash issue during reconnect
 * Fixed crash issue in `UpdateReadReceipt`

--- a/Plugins_UE_5.2/Sendbird/Source/Sendbird/include/SBDUserMessage.h
+++ b/Plugins_UE_5.2/Sendbird/Source/Sendbird/include/SBDUserMessage.h
@@ -53,6 +53,7 @@ public:
 
 private:
 	SBDUserMessage(const std::string& dict);
+    ~SBDUserMessage() override;
 	void SetSender(const SBDUser& sender);
 	void Overwrite(SBDUserMessage* message);
 


### PR DESCRIPTION
* Fixed crash issue in `DeallocateAllMessages`